### PR TITLE
PDF Icon

### DIFF
--- a/assets/css/index.pcss
+++ b/assets/css/index.pcss
@@ -7,7 +7,7 @@ html {
   color: #363737;
 }
 
-a[href$=".pdf"]:before {
+a[href$=".pdf"]:after {
   width: 14px;
   height: 18px;
   margin-right: 0.35rem;


### PR DESCRIPTION
Moved "after" instead of "before". Reads easier when in context.